### PR TITLE
Migrate to V2 API

### DIFF
--- a/custom_components/medusa/manifest.json
+++ b/custom_components/medusa/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "medusa",
   "name": "Medusa Upcoming TV Shows",
-  "documentation": "https://github.com/the-jeffski/hass-medusa",
+  "documentation": "https://github.com/IDmedia/hass-medusa",
   "requirements": [],
   "dependencies": [],
   "version": "1.0.2",
   "codeowners": [
-    "@IDmedia @the-jeffski"
+    "@IDmedia"
   ]
 }

--- a/custom_components/medusa/manifest.json
+++ b/custom_components/medusa/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/IDmedia/hass-medusa",
   "requirements": [],
   "dependencies": [],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "codeowners": [
     "@IDmedia"
   ]

--- a/custom_components/medusa/manifest.json
+++ b/custom_components/medusa/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "medusa",
   "name": "Medusa Upcoming TV Shows",
-  "documentation": "https://github.com/IDmedia/hass-medusa",
+  "documentation": "https://github.com/the-jeffski/hass-medusa",
   "requirements": [],
   "dependencies": [],
   "version": "1.0.2",
   "codeowners": [
-    "@IDmedia"
+    "@IDmedia @the-jeffski"
   ]
 }

--- a/custom_components/medusa/sensor.py
+++ b/custom_components/medusa/sensor.py
@@ -111,7 +111,8 @@ class MedusaSensor(Entity):
                 card_items["studio"] = show["network"]
                 card_items["title"] = show["showName"]
                 card_items["episode"] = show["epName"]
-                card_items["release"] = '$day, $date $time'
+                card_items["release"] = show["airdate"]
+                card_items["runtime"] = show["runtime"]
                 card_items["poster"] = self.add_poster(lst_images, directory, poster, show["showSlug"], card_items, del_images)
                 card_items["fanart"] = self.add_fanart(lst_images, directory, fanart, show["showSlug"], card_items, del_images)
                 card_items["banner"] = self.add_banner(lst_images, directory, banner, show["showSlug"], card_items, del_images)                

--- a/custom_components/medusa/sensor.py
+++ b/custom_components/medusa/sensor.py
@@ -170,7 +170,7 @@ class MedusaSensor(Entity):
             if banner in del_images:
                del_images.remove(banner)
         else:
-            img_data = requests.get("{0}://{1}:{2}/api/v1/{4}/?cmd=show.getbanner&indexerid={4}".format(self.protocol, self.host, self.port, self.web_root, self.token, id))
+            img_data = requests.get("{0}://{1}:{2}/api/v1/{4}/?cmd=show.getbanner&indexerid={5}".format(self.protocol, self.host, self.port, self.web_root, self.token, id))
 
             if not img_data.status_code.__eq__(200):
                 return ""

--- a/custom_components/medusa/sensor.py
+++ b/custom_components/medusa/sensor.py
@@ -33,7 +33,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    add_entities([MedusaSensor(config, hass)])
+    add_entities([MedusaSensor(config, hass)], True)
 
 
 class MedusaSensor(Entity):


### PR DESCRIPTION
I spotted an issue where I was missing posters for some of my shows. Digging further it was all the ones indexed by TMDB instead of TVDB. The V1 API doesn't support this so gives the wrong ID back which means then the images are not fetched.  
So to fix, I reworked the requests to use V2 api calls. Have had this running now for a week without issue so created a pull in case you want to merge in /cherry pick bits! 